### PR TITLE
Feat/tenure timestamps

### DIFF
--- a/fluff/helpers/sv_config.py
+++ b/fluff/helpers/sv_config.py
@@ -24,7 +24,10 @@ def make_config(sid):
 def get_config(sid, part, key):
     config = fill_config(sid)
 
-    return config[part][key]
+    if part not in config:
+        return None
+
+    return config[part][key] if key in config[part] else None
 
 
 def fill_config(sid):


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5aaf353b-e6d6-41bc-9516-c48a5b114b27)

also the bot won't crash on every message if a config option is missing (unless another command crashes if `get_config()` returns `None`)