### PR TITLE
various rulepush changes and bug fixes

### DIFF
--- a/fluff/assets/rule_example.yml
+++ b/fluff/assets/rule_example.yml
@@ -2,6 +2,10 @@
 #automatically be displayed as "Rule 1. your rule title name here."
 title: your rule title name here
 
+#whether this rule should be hidden, and should only be displayed for users who are rulepushed
+#0 is false, 1 is true
+hidden: 0
+
 #this is the content of the rule. each line MUST be indented.
 #the | must remain untouched.
 #use double curly braces {{}} for areas of the rule you would like rulepush to apply.

--- a/fluff/cogs/noreply.py
+++ b/fluff/cogs/noreply.py
@@ -359,9 +359,7 @@ class Reply(Cog):
                     file=discord.File("assets/noreply.png"))
             elif violation_count >= violation_threshold:
                 self.remove_user_violation_count(message.guild.id, message.author.id)
-                return self.bot.dispatch(
-                    "violation_threshold_reached", message, message.author
-                )
+                return self.bot.dispatch("ping_violation_threshold_reached", message)
             elif (violation_count % remind_frequency) == 0:
                 await notify_modlog("Reminder sent.")
                 return await message.author.send(

--- a/fluff/cogs/rule_push.py
+++ b/fluff/cogs/rule_push.py
@@ -6,9 +6,12 @@ import discord
 from discord.ext import commands
 from discord.ext.commands import Cog
 
+from database.model.LeaderboardEntry import LeaderboardEntry
 from database.model.RolebanSession import RolebanSession, RolebanSessionUser
+from database.repository.rule_push_leaderboard_repository import RulePushLeaderboardRepository
 from database.repository.rule_push_repository import RulePushRepository
 from database.repository.rule_repository import RuleRepository
+from database.repository.user_metadata_repository import UserMetadataRepository
 from helpers.checks import ismod, check_if_target_is_staff
 from helpers.embeds import (
     stock_embed,
@@ -23,9 +26,7 @@ from model.RolebanType import RolebanType
 
 CHANNEL_NAME_PATTERN = re.compile(r"^rulepush(\d+)$")
 DISCORD_MESSAGE_LIMIT = 2000
-
-MAX_ANSWER_MESSAGE_LENGTH = 100
-
+MAX_MILLISECONDS_RULEPUSH_LEADERBOARD = 86400000
 
 class RulePush(Cog):
     """Forces a user to re-read the rules.
@@ -37,24 +38,29 @@ class RulePush(Cog):
     def __init__(self, bot):
         self.bot = bot
         self.rule_push_repo: RulePushRepository = RulePushRepository(self.bot.db)
+        self.rule_push_leaderboard_repo: RulePushLeaderboardRepository = RulePushLeaderboardRepository(self.bot.db)
+        self.user_metadata_repo: UserMetadataRepository = UserMetadataRepository(self.bot.db)
         self.rule_repo: RuleRepository = RuleRepository(self.bot.db)
 
-    async def send_long_message(self, channel: discord.TextChannel, text: str):
+    async def send_long_message(self, channel: discord.TextChannel, text: str) -> discord.Message:
         """Sends text if its under the message limit, otherwise sends the message in fixed DISCORD_MESSAGE_LIMIT-sized chunks."""
         lines = text.split("\n")
         current_chunk = ""
 
+        final_message: discord.Message = None
         for line in lines:
             # +1 for the newline we'll add
             if len(current_chunk) + len(line) + 1 > DISCORD_MESSAGE_LIMIT:
                 if current_chunk:
-                    await channel.send(current_chunk, allowed_mentions=discord.AllowedMentions.none())
+                    final_message = await channel.send(current_chunk, allowed_mentions=discord.AllowedMentions.none())
                 current_chunk = line
             else:
                 current_chunk = current_chunk + "\n" + line if current_chunk else line
 
         if current_chunk:
-            await channel.send(current_chunk, allowed_mentions=discord.AllowedMentions.none())
+            final_message = await channel.send(current_chunk, allowed_mentions=discord.AllowedMentions.none())
+
+        return final_message
 
     @commands.check(ismod)
     @commands.guild_only()
@@ -79,67 +85,8 @@ class RulePush(Cog):
             )
         if member.id == ctx.author.id:
             return await ctx.reply("You cannot rulepush yourself.", mention_author=False)
-        if member.bot:
-            return await ctx.reply("You cannot rulepush a bot.", mention_author=False)
-        if check_if_target_is_staff(self.bot, member, self.bot.config_service):
-            return await ctx.reply("You cannot rulepush staff members.", mention_author=False)
 
-        try:
-            rules = await self.rule_repo.get_rules(ctx.guild.id)
-            all_keywords = await self.rule_push_repo.get_keywords(ctx.guild.id)
-        except sqlite3.Error as err:
-            self.bot.log.error(f"Error loading rules/keywords for server {ctx.guild.id}: {err}")
-            return await ctx.reply("Database error while loading rules and keywords.", mention_author=False)
-
-        if not rules:
-            return await ctx.reply("No rules exist yet! Use `pls help rule`.", mention_author=False)
-
-        chosen_keywords = select_push_keywords(all_keywords)
-        if chosen_keywords is None:
-            return await ctx.reply(
-                f"At least {KEYWORDS_PER_PUSH} distinct keywords are required! Use `pls rulepush add`.",
-                mention_author=False,
-            )
-
-        rendered_rules = render_rules(rules, chosen_keywords)
-        if rendered_rules is None:
-            return await ctx.reply(
-                f"Not enough `{{{{}}}}` slots in the rules! At least {KEYWORDS_PER_PUSH} eligible slots are required.",
-                mention_author=False,
-            )
-
-        session: RolebanSession = await self.bot.roleban_service.roleban_users(ctx, [member], RolebanType.RULEPUSH)
-        if session is None:
-            return
-
-        try:
-            await self.rule_push_repo.create_rulepush_session_keywords(session.id, chosen_keywords)
-        except sqlite3.Error as err:
-            self.bot.log.error(f"Error while adding keyword for rulepush session: {err}")
-            await self.bot.roleban_service.unroleban_user(ctx, session, member.id, ctx.guild.get_channel(session.channel_id))
-            await self.bot.roleban_service.delete_roleban_channel(self.bot.get_channel(session.channel_id), "Keyword DB setup failed, deleting channel", session.id)
-            return await ctx.reply(f"Error while creating rulepush session: {err}", mention_author=False)
-
-        rulepush_channel: discord.TextChannel = self.bot.get_channel(session.channel_id)
-        rules_message = ""
-        for rule in rendered_rules:
-            rules_message += f"**Rule {rule.rule_number}. {rule.title}**\n{rule.content}"
-
-
-        await self.send_long_message(rulepush_channel, rules_message)
-
-        await rulepush_channel.send(
-            f"{member.mention}, you've been sent here by staff to re-read the server rules.\n\n"
-            f"Hidden in the rules above are **{KEYWORDS_PER_PUSH} words that don't belong**. "
-            f"Read carefully and type each out-of-place word in this channel. "
-            f"Once you have found all {KEYWORDS_PER_PUSH} words, you will be automatically removed from this channel.",
-            allowed_mentions=discord.AllowedMentions(users=True),
-        )
-
-        try:
-            await ctx.message.add_reaction("📖")
-        except (discord.Forbidden, discord.HTTPException):
-            pass
+        return await self.perform_rulepush(ctx, member)
 
     @commands.bot_has_permissions(manage_roles=True, manage_channels=True)
     @commands.check(ismod)
@@ -200,20 +147,23 @@ class RulePush(Cog):
             status = "🔴 Active" if user.status == RolebanStatus.ACTIVE.value else "🚪 User left"
             dt = datetime.fromtimestamp(session.created_at, tz=timezone.utc)
 
-            keywords = None
+            found_keywords: list[str] = []
+            not_found_keywords: list[str] = []
             try:
-                keywords = await self.rule_push_repo.get_keywords_for_session(session.id)
+                found_keywords, not_found_keywords = await self.rule_push_repo.get_keywords_for_session(session.id)
             except sqlite3.Error as err:
                 self.bot.log.error(f"error fetching keywords for session {session.id}: {err}")
 
-            keyword_value = ", ".join(keywords) if keywords else "Could not fetch keywords"
+            found_keyword_value = ", ".join(found_keywords) if found_keywords else "None"
+            not_found_keyword_value = ", ".join(not_found_keywords) if not_found_keywords else "None"
 
             embed.add_field(
                 name=f"{status} - #{channel.name}" if channel else status,
                 value=(
                     f"> User: <@{user.user_id}>\n"
                     f"> Channel: {location}\n"
-                    f"> Keywords: {keyword_value}\n"
+                    f"> Found keywords: {found_keyword_value}\n"
+                    f"> Unfound Keywords: {not_found_keyword_value}\n"
                     f"> Rolebanned by: <@{user.rolebanned_by}>\n"
                     f"> Rolebanned: {discord.utils.format_dt(dt, 'R')}"
                 ),
@@ -230,6 +180,10 @@ class RulePush(Cog):
         """This lists the rulepush keywords for this server.
 
         No arguments."""
+        should_print_keywords: bool = await self.confirm_action(ctx, ctx.channel)
+        if not should_print_keywords:
+            return
+
         try:
             server_keywords: list[str] = await self.rule_push_repo.get_keywords(ctx.guild.id)
         except sqlite3.Error as err:
@@ -323,6 +277,131 @@ class RulePush(Cog):
 
         return await ctx.reply(f"no keywords were deleted, they did not exist.", mention_author=False)
 
+
+    @rulepush.command(aliases=["leaderboards"])
+    @commands.guild_only()
+    async def leaderboard(self, ctx: commands.Context):
+        """Returns the top 20 fastest rulepush times"""
+        leaderboard_entries: list[LeaderboardEntry] = await self.rule_push_leaderboard_repo.get_rule_push_leaderboard()
+
+        if not leaderboard_entries:
+            return await ctx.reply("No rulepush leaderboard entries found.", mention_author=False)
+
+        embed = stock_embed(self.bot)
+        embed.title = "🏆 Rule Push Leaderboard"
+        embed.color = discord.Color.gold()
+
+        medals = {0: "🥇", 1: "🥈", 2: "🥉"}
+        lines = []
+
+        for rank, entry in enumerate(leaderboard_entries):
+            position = medals.get(rank, f"**{rank + 1}.**")
+            minutes, remainder_ms = divmod(entry.completion_time, 60000)
+            seconds = remainder_ms / 1000
+            time_str = f"{minutes}m, {seconds:.3f}s"
+            date_str = f"<t:{entry.completion_date}:d> at <t:{entry.completion_date}:T>"
+            lines.append(f"{position} **{time_str}** by <@{entry.user_id}> ({entry.user_name}) on {date_str}\n")
+
+        embed.description = "\n".join(lines)
+        embed.set_footer(text=f"Top 20 entries")
+
+        return await ctx.reply(embed=embed, mention_author=False)
+
+    @rulepush.command(aliases=["myself"])
+    @commands.bot_has_permissions(manage_roles=True, manage_channels=True)
+    @commands.guild_only()
+    async def me(self, ctx: commands.Context):
+        """Rolebans the user who invoked the method"""
+        if ctx.author is None or ctx.guild is None:
+            return await ctx.reply("You must be in a server to do this.", mention_author=False)
+
+        return await self.perform_rulepush(ctx, ctx.author)
+
+    @Cog.listener()
+    async def on_ping_violation_threshold_reached(self, message: discord.Message):
+        ctx: commands.Context = await self.bot.get_context(message)
+        if ctx is None or ctx.author is None or ctx.guild is None:
+            return
+
+        await self.perform_rulepush(ctx, ctx.author, True)
+        return await message.reply(
+                    f"**{self.bot.pacify_name(message.author.name)}** has been automatically rulepushed for reaching the reply ping preference violation threshold."
+                )
+
+    async def perform_rulepush(self, ctx: commands.Context, member: discord.Member, ping_violation: bool = False):
+        """performs the actual rulepush action"""
+        if member.bot:
+            return await ctx.reply("You cannot rulepush a bot.", mention_author=False)
+        if check_if_target_is_staff(self.bot, member, self.bot.config_service):
+            return await ctx.reply("You cannot rulepush staff members.", mention_author=False)
+
+        try:
+            rules = await self.rule_repo.get_rules(ctx.guild.id)
+            all_keywords = await self.rule_push_repo.get_keywords(ctx.guild.id)
+        except sqlite3.Error as err:
+            self.bot.log.error(f"Error loading rules/keywords for server {ctx.guild.id}: {err}")
+            return await ctx.reply("Database error while loading rules and keywords.", mention_author=False)
+
+        if not rules:
+            return await ctx.reply("No rules exist yet! Use `pls help rule`.", mention_author=False)
+
+        chosen_keywords = select_push_keywords(all_keywords)
+        if chosen_keywords is None:
+            return await ctx.reply(
+                f"At least {KEYWORDS_PER_PUSH} distinct keywords are required! Use `pls rulepush add`.",
+                mention_author=False,
+            )
+
+        rendered_rules = render_rules(rules, chosen_keywords)
+        if rendered_rules is None:
+            return await ctx.reply(
+                f"Not enough `{{{{}}}}` slots in the rules! At least {KEYWORDS_PER_PUSH} eligible slots are required.",
+                mention_author=False,
+            )
+
+        session: RolebanSession = await self.bot.roleban_service.roleban_users(ctx, [member], RolebanType.RULEPUSH)
+        if session is None:
+            return
+
+        try:
+            await self.rule_push_repo.create_rulepush_session_keywords(session.id, chosen_keywords)
+        except sqlite3.Error as err:
+            self.bot.log.error(f"Error while adding keyword for rulepush session: {err}")
+            await self.bot.roleban_service.unroleban_user(ctx, session, member.id, ctx.guild.get_channel(session.channel_id))
+            await self.bot.roleban_service.delete_roleban_channel(self.bot.get_channel(session.channel_id), "Keyword DB setup failed, deleting channel", session.id)
+            return await ctx.reply(f"Error while creating rulepush session: {err}", mention_author=False)
+
+        rulepush_channel: discord.TextChannel = self.bot.get_channel(session.channel_id)
+        rules_message = ""
+        for rule in rendered_rules:
+            if rule.rule_number < 0:
+                rules_message += f"**{rule.title}**\n{rule.content}"
+            else:
+                rules_message += f"**Rule {rule.rule_number}. {rule.title}**\n{rule.content}"
+
+        final_message: discord.Message = await self.send_long_message(rulepush_channel, rules_message)
+        epoch_start_time_ms = int(final_message.created_at.timestamp() * 1000)
+        await self.bot.roleban_service.update_session_start_time(session.id, epoch_start_time_ms)
+
+        await rulepush_channel.send(
+            f"{member.mention}, you've been sent here by staff to re-read the server rules.\n\n"
+            f"Hidden in the rules above are **{KEYWORDS_PER_PUSH} words that don't belong**. "
+            f"Read carefully and type each out-of-place word in this channel. "
+            f"Once you have found all {KEYWORDS_PER_PUSH} words, you will be automatically removed from this channel.",
+            allowed_mentions=discord.AllowedMentions(users=True),
+        )
+
+        if ping_violation:
+            await rulepush_channel.send(
+                f"For future reference, please pay attention to a users ping preference.",
+                file=discord.File("assets/noreply.png"),
+            )
+
+        try:
+            await ctx.message.add_reaction("📖")
+        except (discord.Forbidden, discord.HTTPException):
+            pass
+
     @Cog.listener()
     async def on_message(self, message: discord.Message):
         """Checks messages in rulepush channels against the sessions remaining keywords"""
@@ -335,7 +414,7 @@ class RulePush(Cog):
         if check_if_target_is_staff(self.bot, message.author, self.bot.config_service):
             return
 
-        session = await self.bot.roleban_service.get_roleban_session_by_channel(message.guild.id, message.channel.id)
+        session: RolebanSession = await self.bot.roleban_service.get_roleban_session_by_channel(message.guild.id, message.channel.id)
         if session is None or session.users is None or len(session.users) <= 0:
             return
 
@@ -346,11 +425,11 @@ class RulePush(Cog):
         if session_user_status != RolebanStatus.ACTIVE.value or session_user_id != message.author.id:
             return
 
-        if len(message.content) > MAX_ANSWER_MESSAGE_LENGTH:
-            return await message.channel.send("That's a lot of text! Type one word at a time.", mention_author=False)
+        guessed_word: str = message.content.lower().strip()
+        if len(guessed_word.split()) > 1:
+            return await message.channel.send("I don't recognize that message! Please send each word separately and alone in its own message!", mention_author=False)
 
         try:
-            guessed_word = message.content.lower().strip()
             updated, found_count, total = await self.rule_push_repo.mark_keyword_found_and_count(session.id, guessed_word)
         except sqlite3.Error as err:
             self.bot.log.error(f"Error marking keyword found for rulepush session {session.id}: {err}")
@@ -360,6 +439,21 @@ class RulePush(Cog):
             return  # not a keyword or already found
 
         if found_count >= total:
+            if session.start_time > 0:
+                #make sure user metadata is up to date with users name
+                try:
+                    await self.user_metadata_repo.update_user_metadata(message.author.id, message.author.name)
+                except sqlite3.Error as err:
+                    self.bot.log.error(f"Error updating user_metadata for {message.author.id}: {err}")
+
+                end_time = int(message.created_at.timestamp() * 1000)
+                total_elapsed_millis = end_time - session.start_time
+                if total_elapsed_millis < MAX_MILLISECONDS_RULEPUSH_LEADERBOARD:
+                    try:
+                        await self.rule_push_leaderboard_repo.update_rule_push_leaderboard(message.author.id, total_elapsed_millis, int(message.created_at.timestamp()))
+                    except sqlite3.Error as err:
+                        self.bot.log.error(f"Error updating rulepush leaderboard for {message.author.id}: {err}")
+
             ctx: commands.Context = await self.bot.get_context(message)
             released = await self.bot.roleban_service.unroleban_user(ctx, session, message.author.id, message.channel)
             if released:
@@ -465,7 +559,8 @@ class RulePush(Cog):
             keywords = None
             try:
                 rules = await self.rule_repo.get_rules(member.guild.id)
-                keywords = await self.rule_push_repo.get_keywords_for_session(session.id)
+                found_keywords, not_found_keywords = await self.rule_push_repo.get_keywords_for_session(session.id)
+                keywords = found_keywords + not_found_keywords
             except sqlite3.Error as err:
                 self.bot.log.error(f"Error loading rules/keywords for user {member.id}: {err}")
                 return await channel.send("error loading rules/keywords.")
@@ -476,7 +571,10 @@ class RulePush(Cog):
 
             rules_message = ""
             for rule in rendered_rules:
-                rules_message += f"**Rule {rule.rule_number}. {rule.title}**\n{rule.content}"
+                if rule.rule_number < 0:
+                    rules_message += f"**{rule.title}**\n{rule.content}"
+                else:
+                    rules_message += f"**Rule {rule.rule_number}. {rule.title}**\n{rule.content}"
 
             await self.send_long_message(channel, rules_message)
 
@@ -496,6 +594,20 @@ class RulePush(Cog):
         embed.color = discord.Color.red()
         embed.description = f"{member.mention} rejoined with a pending rulepush, but {reason}."
         return await self.bot.notification_service.send_notification(member.guild, embed)
+
+    async def confirm_action(self, ctx: commands.Context, channel: discord.abc.GuildChannel) -> bool:
+        """Waits up to one minute for the purge invoking user to confirm they actually want to purge
+
+        Returns: true if a purge should actually occur, false otherwise"""
+        await ctx.reply(
+            "**WARNING: sensitive information. Do not invoke command in general chat**. Type `yes` to continue, or `no` to cancel. (I will wait 1 minute for your response before automatically cancelling the command)",
+            mention_author=False)
+        response: discord.Message = await self.bot.await_message(channel, ctx.author, 60)
+        if response is None or response.content.lower() != "yes":
+            await ctx.reply("command cancelled", mention_author=False)
+            return False
+
+        return True
 
 async def setup(bot):
     await bot.add_cog(RulePush(bot))

--- a/fluff/cogs/rules.py
+++ b/fluff/cogs/rules.py
@@ -34,61 +34,17 @@ class Rules(Cog):
 
         - `number`
         The rule associated with this rule number to post. Optional."""
-        summary_embed = stock_embed(self.bot)
-        summary_embed.title = "Rules"
-        summary_embed.color = discord.Color.red()
-        summary_embed.set_author(
-            name=ctx.author, icon_url=ctx.author.display_avatar.url
-        )
+        await self.get_rule_info(ctx, False, number)
 
-        if not number:
-            server_rules: list[Rule] = []
-            try:
-                server_rules = await self.rule_repo.get_rules(ctx.guild.id)
-            except sqlite3.Error as err:
-                self.bot.log.error(f"Error getting rule list for server {ctx.guild.id}: {err}")
-                return await ctx.reply("Error getting rule list", mention_author=False)
 
-            if not server_rules:
-                summary_embed.add_field(
-                    name="No Rules",
-                    value="There are no rules available in this server.",
-                    inline=False,
-                )
-            else:
-                for rule in server_rules:
-                    summary_embed.add_field(
-                        name=f"**{rule.rule_number}**",
-                        value=f"> **{io.StringIO(rule.title).readline()}.**",
-                        inline=False,
-                    )
+    @commands.bot_has_permissions(embed_links=True)
+    @commands.guild_only()
+    @commands.group(aliases=["hiddenrules"], invoke_without_command=True)
+    @commands.check(isadmin)
+    async def hiddenrule(self, ctx: commands.Context, *, number=None):
+        """Displays hidden rules. Only viewable by mods"""
+        await self.get_rule_info(ctx, True, number)
 
-            return await ctx.reply(embed=summary_embed, mention_author=False)
-
-        try:
-            number = int(number)
-        except ValueError:
-            return await ctx.reply("Please provide a valid number", mention_author=False)
-
-        rule: Rule | None = None
-        try:
-            rule = await self.rule_repo.get_rule_by_number(ctx.guild.id, number)
-        except sqlite3.Error as err:
-            self.bot.log.error(f"Error getting rule for server {ctx.guild.id}: {err}")
-            return await ctx.reply("Error getting rule with that rule number", mention_author=False)
-
-        if rule:
-            return await ctx.reply(
-                content=f"**Rule {rule.rule_number}. {rule.title}.**\n{rule.content.replace("{{", "").replace("}}", "")}",
-                mention_author=False,
-                allowed_mentions=discord.AllowedMentions.none(),
-            )
-        else:
-            return await ctx.reply(
-                content=f"Rule `{number}` not found.",
-                mention_author=False,
-                allowed_mentions=discord.AllowedMentions.none(),
-            )
 
     @commands.check(isadmin)
     @rule.command(aliases=["add"])
@@ -111,9 +67,10 @@ class Rules(Cog):
 
         title = parsed_rules["title"]
         content = parsed_rules["content"]
+        hidden = parsed_rules["hidden"]
 
         try:
-            await self.rule_repo.add_rule(ctx.guild.id, title, content)
+            await self.rule_repo.add_rule(ctx.guild.id, title, content, hidden)
         except sqlite3.Error as err:
             self.bot.log.error(f"Error attempting to add new rule to rules table for server {ctx.guild.id}: {err}")
             return await ctx.reply(f"Error trying to add rule.", mention_author=False)
@@ -169,6 +126,67 @@ class Rules(Cog):
 
         return await ctx.reply(f"Rule {rule_number} not found.", mention_author=False)
 
+    async def get_rule_info(self, ctx: commands.Context, hidden: bool, number: int | None):
+        summary_embed = stock_embed(self.bot)
+        summary_embed.title = "Rules"
+        summary_embed.color = discord.Color.red()
+        summary_embed.set_author(
+            name=ctx.author, icon_url=ctx.author.display_avatar.url
+        )
+
+        if not number:
+            server_rules: list[Rule] = []
+            try:
+                server_rules = await self.rule_repo.get_rules(ctx.guild.id)
+                if hidden:
+                    server_rules = [db_rule for db_rule in server_rules if db_rule.rule_number < 0]
+                else:
+                    server_rules = [db_rule for db_rule in server_rules if db_rule.rule_number > 0]
+            except sqlite3.Error as err:
+                self.bot.log.error(f"Error getting rule list for server {ctx.guild.id}: {err}")
+                return await ctx.reply("Error getting rule list", mention_author=False)
+
+            if not server_rules:
+                summary_embed.add_field(
+                    name="No Rules",
+                    value="There are no rules available in this server.",
+                    inline=False,
+                )
+            else:
+                for rule in server_rules:
+                    summary_embed.add_field(
+                        name=f"**{rule.rule_number}**",
+                        value=f"> **{io.StringIO(rule.title).readline()}.**",
+                        inline=False,
+                    )
+
+            return await ctx.reply(embed=summary_embed, mention_author=False)
+
+        try:
+            number = int(number)
+        except ValueError:
+            return await ctx.reply("Please provide a valid number", mention_author=False)
+
+        rule: Rule | None = None
+        try:
+            rule = await self.rule_repo.get_rule_by_number(ctx.guild.id, number)
+        except sqlite3.Error as err:
+            self.bot.log.error(f"Error getting rule for server {ctx.guild.id}: {err}")
+            return await ctx.reply("Error getting rule with that rule number", mention_author=False)
+
+        if rule and ((hidden is True and rule.rule_number < 0) or (hidden is False and rule.rule_number > 0)):
+            return await ctx.reply(
+                content=f"**Rule {rule.rule_number}. {rule.title}.**\n{rule.content.replace("{{", "").replace("}}", "")}",
+                mention_author=False,
+                allowed_mentions=discord.AllowedMentions.none(),
+            )
+        else:
+            return await ctx.reply(
+                content=f"Rule `{number}` not found.",
+                mention_author=False,
+                allowed_mentions=discord.AllowedMentions.none(),
+            )
+
     async def validate_attachment(self, ctx: commands.Context, attachment: discord.Attachment) -> dict | None:
         """Validates the attachment, ensuring the file and its contents are as expected
         Returns: dict if the validation passed, otherwise None"""
@@ -193,6 +211,14 @@ class Rules(Cog):
 
         if "title" not in parsed_rules or "content" not in parsed_rules:
             await ctx.reply("Rule file must contain both `title` and `content`.", mention_author=False)
+            return None
+
+        if "hidden" not in parsed_rules:
+            await ctx.reply("Rule file must contain `hidden` field.", mention_author=False)
+            return None
+
+        if not isinstance(parsed_rules["hidden"], int) or parsed_rules["hidden"] < 0 or parsed_rules["hidden"] > 1:
+            await ctx.reply("`hidden` field must be set to either 0 or 1", mention_author=False)
             return None
 
         if not isinstance(parsed_rules["title"], str) or not isinstance(parsed_rules["content"], str):

--- a/fluff/cogs/tenure.py
+++ b/fluff/cogs/tenure.py
@@ -193,6 +193,9 @@ class Tenure(Cog):
         status_msg = await ctx.reply("Processing..", mention_author=False)
 
         if tenure_disabled_role in user.roles:
+            await user.remove_roles(
+                tenure_disabled_role, reason=f"Fluff Tenure (Prohibition enforcement: Enablement)"
+            )
             await user.add_roles(
                 tenure_role, reason="Fluff Tenure (Prohibition enforcement: Enablement)"
             )

--- a/fluff/database/migration/V8__additional_rulepush_tables.sql
+++ b/fluff/database/migration/V8__additional_rulepush_tables.sql
@@ -1,0 +1,13 @@
+ALTER TABLE rule ADD COLUMN hidden INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE roleban_session ADD COLUMN start_time TEXT NOT NULL DEFAULT '-1'; --for rulepush leaderboard timing
+
+CREATE TABLE user_metadata (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL
+) STRICT;
+
+CREATE TABLE rule_push_leaderboard (
+    user_id TEXT PRIMARY KEY,
+    completion_time INTEGER NOT NULL,
+    completion_date INTEGER NOT NULL
+) STRICT;

--- a/fluff/database/model/LeaderboardEntry.py
+++ b/fluff/database/model/LeaderboardEntry.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class LeaderboardEntry:
+    user_id: int #the users discord ID
+    user_name: str #the users discord name
+    completion_time: int #how long, in seconds, the user took to finish
+    completion_date: int #the date, in epoch format, when the user attained this entry

--- a/fluff/database/model/RolebanSession.py
+++ b/fluff/database/model/RolebanSession.py
@@ -16,3 +16,4 @@ class RolebanSession:
     type: RolebanType               # the type of roleban, e.g. rulepush or toss
     users: list[RolebanSessionUser] # the list of users who are apart of this roleban session
     created_at: int                 # the epoch timestamp representing when this roleban first occurred
+    start_time: int                 # the epoch timestamp representing when the final rulepush message was inserted. -1 if roleban that is not a rulepush

--- a/fluff/database/repository/roleban_repository.py
+++ b/fluff/database/repository/roleban_repository.py
@@ -21,7 +21,8 @@ class RolebanRepository:
                 "SELECT rs.id AS id, rs.server_id AS server_id, rs.channel_id AS channel_id, rs.type AS type, rs.created_at AS created_at, "
                 "GROUP_CONCAT(rsu.user_id) AS user_ids, "
                 "GROUP_CONCAT(rsu.rolebanned_by) AS rolebanned_bys, "
-                "GROUP_CONCAT(rsu.status) AS statuses "
+                "GROUP_CONCAT(rsu.status) AS statuses, "
+                "rs.start_time AS start_time "
                 "FROM roleban_session rs LEFT JOIN roleban_session_user rsu "
                 "ON rs.id = rsu.session_id "
                 "WHERE rs.server_id = ? "
@@ -74,6 +75,7 @@ class RolebanRepository:
                 channel_id=channel_id,
                 type=roleban_type,
                 created_at=created_at,
+                start_time=-1,
                 users=users
             )
 
@@ -128,6 +130,15 @@ class RolebanRepository:
             await conn.commit()
             return cursor.rowcount
 
+    async def update_roleban_start_time(self, session_id: int, start_time: int) -> None:
+        """Sets the start time for this session"""
+        async with self.db.get_write_connection() as conn:
+            cursor = await conn.execute(
+                "UPDATE roleban_session SET start_time = ? WHERE id = ?",
+                (str(start_time), session_id)
+            )
+            await conn.commit()
+
     async def reactivate_user_session(self, session_id: int, user_id: int, channel_id: int) -> int:
         """Reactivates a 'left' session after the user rejoined, pointing the parent session at the (possibly new) channel ID
         Returns: the number of updated rows"""
@@ -151,7 +162,8 @@ class RolebanRepository:
                 "SELECT rs.id AS id, rs.server_id AS server_id, rs.channel_id AS channel_id, rs.type AS type, rs.created_at AS created_at, "
                 "GROUP_CONCAT(rsu.user_id) AS user_ids, "
                 "GROUP_CONCAT(rsu.rolebanned_by) AS rolebanned_bys, "
-                "GROUP_CONCAT(rsu.status) AS statuses "
+                "GROUP_CONCAT(rsu.status) AS statuses, "
+                "rs.start_time AS start_time "
                 "FROM roleban_session rs JOIN roleban_session_user rsu "
                 "ON rs.id = rsu.session_id "
                 "WHERE rs.server_id = ? AND rsu.user_id = ? "
@@ -169,7 +181,8 @@ class RolebanRepository:
                 "SELECT rs.id AS id, rs.server_id AS server_Id, rs.channel_id AS channel_id, rs.type AS type, rs.created_at AS created_at, "
                 "GROUP_CONCAT(rsu.user_id) AS user_ids, "
                 "GROUP_CONCAT(rsu.rolebanned_by) AS rolebanned_bys, "
-                "GROUP_CONCAT(rsu.status) AS statuses "
+                "GROUP_CONCAT(rsu.status) AS statuses, "
+                "rs.start_time AS start_time "
                 "FROM roleban_session rs LEFT JOIN roleban_session_user rsu "
                 "ON rs.id = rsu.session_id "
                 "WHERE rs.server_id = ? AND rs.channel_id = ? "
@@ -209,5 +222,6 @@ class RolebanRepository:
             channel_id=int(row["channel_id"]) if row["channel_id"] is not None else None,
             type=RolebanType(row["type"]),
             created_at=int(row["created_at"]),
+            start_time=int(row["start_time"]),
             users=users
         )

--- a/fluff/database/repository/rule_push_leaderboard_repository.py
+++ b/fluff/database/repository/rule_push_leaderboard_repository.py
@@ -1,0 +1,52 @@
+from database.database import Database
+from database.model.LeaderboardEntry import LeaderboardEntry
+
+"""Repository class responsible for handling any reads and writes to the rule push leaderboard table"""
+class RulePushLeaderboardRepository:
+    def __init__(self, db: Database):
+        self.db = db
+
+    async def get_rule_push_leaderboard(self) -> list[LeaderboardEntry]:
+        """Fetches all rule push leaderboard entries"""
+        async with self.db.get_read_connection() as conn:
+            cursor = await conn.execute(
+                "SELECT rpl.user_id, COALESCE(um.name, 'Unknown Name') AS name, rpl.completion_time, rpl.completion_date "
+                "FROM rule_push_leaderboard rpl "
+                "LEFT JOIN user_metadata um "
+                "ON rpl.user_id = um.id "
+                "ORDER BY rpl.completion_time ASC, rpl.completion_date ASC "
+                "LIMIT 20"
+            )
+            rows = await cursor.fetchall()
+
+        leaderboard_entries: list[LeaderboardEntry] = []
+        for row in rows:
+            user_id, name, completion_time, completion_date = row
+            user_id = int(user_id)
+            completion_time = int(completion_time)
+            completion_date = int(completion_date)
+            leaderboard_entries.append(LeaderboardEntry(user_id, name, completion_time, completion_date))
+
+        return leaderboard_entries
+
+    async def update_rule_push_leaderboard(self, user_id: int, completion_time: int, completion_date: int) -> None:
+        """Updates the rule_push_leaderboard table"""
+        async with self.db.get_write_connection() as conn:
+            await conn.execute(
+                "INSERT INTO rule_push_leaderboard (user_id, completion_time, completion_date) "
+                "VALUES (?, ?, ?) "
+                "ON CONFLICT (user_id) DO UPDATE SET "
+                "completion_time = ?, completion_date = ? "
+                "WHERE completion_time > ?",
+                (str(user_id), completion_time, completion_date, completion_time, completion_date, completion_time),
+            )
+
+            await conn.execute(
+                "DELETE FROM rule_push_leaderboard "
+                "WHERE user_id NOT IN "
+                "(SELECT user_id FROM rule_push_leaderboard "
+                "ORDER BY completion_time ASC, completion_date ASC "
+                "LIMIT 20)"
+            )
+
+            await conn.commit()

--- a/fluff/database/repository/rule_push_repository.py
+++ b/fluff/database/repository/rule_push_repository.py
@@ -51,19 +51,28 @@ class RulePushRepository:
             rows = await cursor.fetchall()
             return [row[0] for row in rows]
 
-    async def get_keywords_for_session(self, session_id: int) -> list[str]:
+    async def get_keywords_for_session(self, session_id: int) -> tuple[list[str], list[str]]:
         """Fetches the keywords for this session
-        Returns: a list of keywords"""
+        Returns: a tuple lists, where the first list are the keywords the user has found, and the second
+        list are the keywords the user has not found"""
         async with self.db.get_read_connection() as conn:
             cursor = await conn.execute(
-                "SELECT keyword "
+                "SELECT keyword, found "
                 "FROM rule_push_session_keyword "
                 "WHERE session_id = ? "
                 "ORDER BY keyword ASC",
                 (session_id,)
             )
             rows = await cursor.fetchall()
-            return [row[0] for row in rows]
+            found_keywords: list[str] = []
+            not_found_keywords: list[str] = []
+            for row in rows:
+                if int(row[1]) == 1:
+                    found_keywords.append(row[0])
+                else:
+                    not_found_keywords.append(row[0])
+
+            return found_keywords, not_found_keywords
 
     async def add_keywords(self, server_id: int, keywords_list: list[str]) -> int:
         """Adds a list of keywords to this server"""

--- a/fluff/database/repository/rule_repository.py
+++ b/fluff/database/repository/rule_repository.py
@@ -44,18 +44,28 @@ class RuleRepository:
             rule_number = int(rule_number)
             return Rule(rule_number, title, content)
 
-    async def add_rule(self, server_id: int, title: str, content: str) -> None:
+    async def add_rule(self, server_id: int, title: str, content: str, hidden: int) -> None:
         """Adds a rule to the rule table"""
         async with self.db.get_write_connection() as conn:
-            #get the next rule number for this server
-            cursor = await conn.execute(
-                "SELECT COALESCE(MAX(rule_number), 0) + 1 "
-                "FROM rule "
-                "WHERE server_id = ?",
-                (str(server_id),)
-            )
-            row = await cursor.fetchone()
-            next_rule_number = int(row[0])
+            next_rule_number: int = 0
+            if hidden == 0:
+                cursor = await conn.execute(
+                    "SELECT COALESCE(MAX(rule_number), 0) + 1 "
+                    "FROM rule "
+                    "WHERE server_id = ?",
+                    (str(server_id),)
+                )
+                row = await cursor.fetchone()
+                next_rule_number = int(row[0])
+            else:
+                cursor = await conn.execute(
+                    "SELECT MIN(COALESCE(MIN(rule_number), 0), 0) - 1 "
+                    "FROM rule "
+                    "WHERE server_id = ?",
+                    (str(server_id),)
+                )
+                row = await cursor.fetchone()
+                next_rule_number = int(row[0])
 
             await conn.execute(
                 "INSERT INTO rule (server_id, rule_number, title, content) "

--- a/fluff/database/repository/user_metadata_repository.py
+++ b/fluff/database/repository/user_metadata_repository.py
@@ -1,0 +1,19 @@
+from database.database import Database
+
+"""Repository class responsible for handling any reads and writes to the user_metadata table"""
+class UserMetadataRepository:
+    def __init__(self, db: Database):
+        self.db = db
+
+    async def update_user_metadata(self, user_id: int, name: str) -> None:
+        """Updates the user_metadata table"""
+        async with self.db.get_write_connection() as conn:
+            await conn.execute(
+                "INSERT INTO user_metadata (id, name) "
+                "VALUES (?, ?) "
+                "ON CONFLICT (id) DO UPDATE SET "
+                "name = ? "
+                "WHERE name != ?",
+                (str(user_id), name, name, name),
+            )
+            await conn.commit()

--- a/fluff/helpers/rulepush_text.py
+++ b/fluff/helpers/rulepush_text.py
@@ -82,12 +82,18 @@ def render_rules(rules: list[Rule], chosen_keywords: list[str]) -> list[Rule] | 
     if chosen_keywords is None or rules is None:
         return None
 
+    rules = sorted(rules, key=sort_key)
     slots = collect_slots(rules)
     if len(slots) < len(chosen_keywords):
         return None
 
     chosen_slots = random.sample(slots, len(chosen_keywords))
     return _apply_slots(rules, list(zip(chosen_slots, chosen_keywords)))
+
+def sort_key(rule: Rule):
+    """Hidden rules are negative, and we need to ensure they come after all the normal rules"""
+    is_negative = rule.rule_number < 0
+    return (is_negative, -rule.rule_number if is_negative else rule.rule_number)
 
 def _apply_slots(rules: list[Rule], chosen: list[tuple]) -> list[Rule]:
     """Applies the chosen (slot, keyword) pairs to their rules.

--- a/fluff/service/RolebanService.py
+++ b/fluff/service/RolebanService.py
@@ -260,6 +260,14 @@ class RolebanService:
 
         return 0
 
+    async def update_session_start_time(self, session_id: int, start_time: int):
+        """Updates the session start time, to accurately reflect when all rules have been posted in
+        a rulepush sessions"""
+        try:
+            await self.roleban_repo.update_roleban_start_time(session_id, start_time)
+        except sqlite3.Error as err:
+            self.bot.log.error(f"Error updating session start time for session ID {session_id}: {err}")
+
     async def reactivate_user_session(self, session_id: int, user_id: int, channel_id: int) -> int:
         """Reactivates a users session by setting the status to ACTIVE and updating the channel ID"""
         try:


### PR DESCRIPTION
1. add ability for additional rules that are only displayed for rulepush
2. send user to rulepush when reaching max ping violations
3. add top 20 leaderboard for rulepush
4. add ability for users to rulepush themselves
5. require confirmation before displaying rulepush keywords
6. update sessions to display found and not-found keywords
7. inform user that each rulepush keyword must be said individually, 1 word per message
8. fix tenure-disable role sticking around after re-enabling tenure for a user